### PR TITLE
Add GIX team as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # The codebase is owned by the Governance & Identity Experience team at DFINITY
 # For questions, reach out to: <gix@dfinity.org>
+@dfinity/gix


### PR DESCRIPTION
This adds the GIX team as the owner of this repo.